### PR TITLE
Ensure that the configuration file is an absolute path in Docker buil…

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -30,6 +30,9 @@ do
 	esac
 done
 
+# Ensure that the configuration file is an absolute path
+CONFIG_FILE=$(realpath -s "$CONFIG_FILE")
+
 # Ensure that the confguration file is present
 if test -z "${CONFIG_FILE}"; then
 	echo "Configuration file need to be present in '${DIR}/config' or path passed as parameter"
@@ -63,7 +66,7 @@ if [ "${CONTAINER_EXISTS}" != "" ] && [ "${CONTINUE}" != "1" ]; then
 fi
 
 # Modify original build-options to allow config file to be mounted in the docker container
-BUILD_OPTS="$(echo ${BUILD_OPTS:-} | sed -E 's@\-c\s?([^ ]+)@-c /config@')"
+BUILD_OPTS="$(echo "${BUILD_OPTS:-}" | sed -E 's@\-c\s?([^ ]+)@-c /config@')"
 
 ${DOCKER} build -t pi-gen "${DIR}"
 if [ "${CONTAINER_EXISTS}" != "" ]; then
@@ -73,7 +76,7 @@ if [ "${CONTAINER_EXISTS}" != "" ]; then
 		--volumes-from="${CONTAINER_NAME}" --name "${CONTAINER_NAME}_cont" \
 		pi-gen \
 		bash -e -o pipefail -c "dpkg-reconfigure qemu-user-static &&
-	cd /pi-gen; ./build.sh ${BUILD_OPTS} ;
+	cd /pi-gen; ./build.sh ${BUILD_OPTS} &&
 	rsync -av work/*/build.log deploy/" &
 	wait "$!"
 else


### PR DESCRIPTION
…d (#306)

* Use `&&` instead of `;` in Docker pipeline

* In case of error, `&&` does not continue execution

* Silence shellcheck warning

* SC2086: Double quote to prevent globbing and word splitting.

* Ensure that the configuration file is an absolute path in Docker build

The specific problem is in commit 2ddd7c1, where the passed config file
(using the `-c` option) is now mounted inside the container using the
`--volume src:dest:opt` Docker option.

The problem is that Docker requires absolute paths for mounting single
files inside the container, otherwise it silently tries to mount a volume
name instead as an empty directory. Therefore the Docker build no longer
works with the following invocation forms (relative config-paths):

    ./build-docker.sh -c myconfig
    /path/to/build-docker.sh -c myconfig   # also doesn't work

This commit uses `realpath` (included in coreutils) in the Docker build
script to ensure that the passed configuration file is always an
absolute path before passing it to Docker.